### PR TITLE
Fix for error when running under Windows 10 WSL

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,8 @@ Vagrant.configure("2") do |config|
         wordpress.vm.provider "virtualbox" do |vb|
             vb.name = "wordpress"
             vb.memory = 512
+            # Added the following line to prevent error running under Windows 10 WSL
+            vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
         end
 
         wordpress.vm.provision "shell", path: "env/local/userdata.sh"


### PR DESCRIPTION
Added a line into `Vagrantfile` to fix the following error when running under Windows 10 WSL:

```
==> wordpress: Booting VM...
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["startvm", "b0db10f2-5565-4e96-9f1f-78f914f8e11f", "--type", "headless"]

Stderr: VBoxManage.exe: error: RawFile#0 failed to create the raw output file /mnt/c/Users/rfallows/xwp/ubuntu-xenial-16.04-cloudimg-console.log (VERR_PATH_NOT_FOUND)
VBoxManage.exe: error: Details: code E_FAIL (0x80004005), component ConsoleWrap, interface IConsole

```